### PR TITLE
Removing patch branch reference from dockerfile

### DIFF
--- a/pkg/oci/Dockerfile
+++ b/pkg/oci/Dockerfile
@@ -14,7 +14,7 @@ USER root
 RUN dnf clean expire-cache ; dnf -y install git python3-pip python3-pip-wheel; dnf clean all
 
 WORKDIR /src
-RUN git clone https://github.com/DUNE-DAQ/dqm-backend.git -b pahamilt/timezone-fix-2
+RUN git clone https://github.com/DUNE-DAQ/dqm-backend.git
 
 RUN pip3 install -r /src/dqm-backend/dqm/dqm/requirements.txt
 


### PR DESCRIPTION
I left the feature branch name I was testing with in the dockerfile by accident. This feature branch no longer exists as it's been merged to develop.